### PR TITLE
Add github run attempt to socket name (ME-3087)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ For more details also see: https://www.border0.com/blogs/ssh-shell-access-to-you
 ## Quickstart
 
 To get started with this action, you'll need to [register a Border0 account](https://portal.border0.com/register), and generate an admin token
-by going to [Border0 Admin Portal](https://portal.border0.com) -> Team -> Service Accounts, create a new service account, then create a token with `Admin` permissions for the service account,
-and then add the token in your GitHub repository's secrets.
+by going to [Border0 Admin Portal](https://portal.border0.com) -> Team -> Service Accounts, create a new service account, then create a token with `Admin` permissions for the service account, and then add the token in your GitHub repository's secrets. More on service accounts here: https://docs.border0.com/docs/service-accounts
 
 ```yaml
 name: My Workflow

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For more details also see: https://www.border0.com/blogs/ssh-shell-access-to-you
 ## Quickstart
 
 To get started with this action, you'll need to [register a Border0 account](https://portal.border0.com/register), and generate an admin token
-by going to [Border0 Admin Portal](https://portal.border0.com) -> Organization Settings -> Access Tokens, create a token in `Admin` permission groups,
+by going to [Border0 Admin Portal](https://portal.border0.com) -> Team -> Service Accounts, create a new service account, then create a token with `Admin` permissions for the service account,
 and then add the token in your GitHub repository's secrets.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ in the [Border0 Admin Portal](https://portal.border0.com).
 The name of the SSH debug socket will follow this naming convention:
 
 ```
-{github-org-name}-{github-repo-name}-{github-workflow-run-id}
+{github-org-name}-{github-repo-name}-{github-workflow-run-id}-{github-workflow-run-attempt}
 ```
 
 ## Automatically trigger on failure

--- a/index.js
+++ b/index.js
@@ -193,7 +193,12 @@ async function run() {
       BORDER0_ADMIN_TOKEN: token
     };
     const repoStr = process.env.GITHUB_REPOSITORY.replace(/\//g, '-');
-    const socketName = `${repoStr}-${process.env.GITHUB_RUN_ID}`;
+    const socketName = `${repoStr}-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}`;
+    // // Backwards compatible
+    // let socketName = `${repoStr}-${process.env.GITHUB_RUN_ID}`;
+    // if (process.env.GITHUB_RUN_ATTEMPT !== '1') {
+    //   socketName = `${socketName}-${process.env.GITHUB_RUN_ATTEMPT}`;
+    // }
     const githubActionPath = process.env.GITHUB_ACTION_PATH || '/tmp/';
 
     // We don't need to create a socket if we are running cleanup

--- a/index.js
+++ b/index.js
@@ -193,12 +193,8 @@ async function run() {
       BORDER0_ADMIN_TOKEN: token
     };
     const repoStr = process.env.GITHUB_REPOSITORY.replace(/\//g, '-');
+    // Adding run attempt to the socket name to avoid conflicts (based on community feedback)
     const socketName = `${repoStr}-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}`;
-    // // Backwards compatible
-    // let socketName = `${repoStr}-${process.env.GITHUB_RUN_ID}`;
-    // if (process.env.GITHUB_RUN_ATTEMPT !== '1') {
-    //   socketName = `${socketName}-${process.env.GITHUB_RUN_ATTEMPT}`;
-    // }
     const githubActionPath = process.env.GITHUB_ACTION_PATH || '/tmp/';
 
     // We don't need to create a socket if we are running cleanup


### PR DESCRIPTION
Based off feedback from @YourKuppa
>I haven't tested this so I don't know if this will work.  But it would hopefully allow a user to re-run a failed job and still allow border0 to work successfully.  At the moment when a job is re-run you get the following error:

<img width="1039" alt="image" src="https://github.com/borderzero/gh-action/assets/526509/9bb464e2-8f8c-4cb9-9832-3aba3c54ad9b">

```
Run borderzero/gh-action@v2
border0 binary not found locally. Downloading...
/usr/bin/curl -s -LJO https://download.border0.com/linux_amd64/border0
/usr/bin/chmod +x border0
/home/runner/work/run-api/run-api/border0 socket create --type ssh --name YourKuppa-run-api-9509864322 --upstream_username runner
2024/06/14 03:03:38 Error: api returned a non 2xx status code (400) with error message: socket name [yourkuppa-run-api-9509864322] validation error: socket name already exists in the same org
Error: The process '/home/runner/work/run-api/run-api/border0' failed with exit code 1
```

testing: the action now adds run number to the name on any run
```
2024-06-14T16:20:44.6478011Z [command]/home/runner/work/experiment/experiment/border0 socket create --type ssh --name borderzero-experiment-9519232807-1 --upstream_username runner
```
![image](https://github.com/borderzero/gh-action/assets/12542797/4bcd5822-5f28-433d-ab4b-0093601ea2e9)

and consecutive run:
![image](https://github.com/borderzero/gh-action/assets/12542797/1478fc1c-cf50-485f-83cb-3b83a4c48203)
