### PR TITLE
FIX: add upstream_username to the connect command

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,6 +184,7 @@ async function createSocketIfNeeded(env, socketName, slackWebhookUrl, token) {
 async function run() {
   try {
     const token = core.getInput('token');
+    const sshUsername = os.userInfo().username;
     const slackWebhookUrl = core.getInput('slack-webhook-url');
     const backgroundMode = core.getInput('background-mode') === 'true';
     const cleanUP = core.getInput('clean-up-mode') === 'true';
@@ -226,7 +227,7 @@ async function run() {
     let bgModeProc;
     const isBoRunning = spawnSync('pgrep', ['-f', `sh -c ./border0 socket connect`]).status === 0;
     if (!isBoRunning) {
-      const connectSocketCommand = `./border0 socket connect ${socketName} --sshserver`;
+      const connectSocketCommand = `./border0 socket connect ${socketName} --sshserver --upstream_username ${sshUsername}`;
 
       bgModeProc = spawn(connectSocketCommand, {
         shell: true,


### PR DESCRIPTION
Reported by community.
While running on self hosted workers socket upstream_username needs to be supplied into the connect

```
2024-11-22T20:33:03.3843268Z ##[group]Run borderzero/gh-action@v2.2-upstreamdata
2024-11-22T20:33:03.3843891Z with:
2024-11-22T20:33:03.3848695Z   token: ***
2024-11-22T20:33:03.3849441Z   slack-webhook-url: ***
2024-11-22T20:33:03.3849833Z   wait-for: 15
2024-11-22T20:33:03.3850108Z   background-mode: false
2024-11-22T20:33:03.3850557Z   clean-up-mode: false
2024-11-22T20:33:03.3850916Z ##[endgroup]
2024-11-22T20:33:03.6047522Z border0 binary not found locally. Downloading...
2024-11-22T20:33:03.6147942Z [command]/usr/bin/curl -s -LJO https://download.border0.com/linux_amd64/border0
2024-11-22T20:33:04.2745344Z [command]/usr/bin/chmod +x border0
2024-11-22T20:33:04.2785482Z [command]/home/runner/work/experiment/experiment/border0 socket create --type ssh --name borderzero-experiment-11979685482-2 --upstream_username runner
2024-11-22T20:33:04.5418158Z Deprecated: Use 'socket create <http|ssh|database|tls|vpn|rdp|vnc|kubernetes>' instead
2024-11-22T20:33:04.8580057Z ┌──────────────────────────────────────┬─────────────────────────────────────┬────────────────────────────────────────────────────┬─────────┬──────┬─────────────┐
2024-11-22T20:33:04.8581922Z │ SOCKET ID                            │ NAME                                │ DNS NAME                                           │ PORT(S) │ TYPE │ DESCRIPTION │
2024-11-22T20:33:04.8583380Z ├──────────────────────────────────────┼─────────────────────────────────────┼────────────────────────────────────────────────────┼─────────┼──────┼─────────────┤
2024-11-22T20:33:04.8585433Z │ 66eff07a-042c-4213-b956-3c9c4fd035fd │ borderzero-experiment-11979685482-2 │ borderzero-experiment-11979685482-2-rnd.border0.io │ 22682   │ ssh  │             │
2024-11-22T20:33:04.8586922Z └──────────────────────────────────────┴─────────────────────────────────────┴────────────────────────────────────────────────────┴─────────┴──────┴─────────────┘
2024-11-22T20:33:04.8587728Z 
2024-11-22T20:33:04.8587903Z Policies:
2024-11-22T20:33:04.8588374Z ┌─────────────┬────────────────────┬───────────────────┐
2024-11-22T20:33:04.8589065Z │ POLICY NAME │ POLICY DESCRIPTION │ ORGANIZATION WIDE │
2024-11-22T20:33:04.8589634Z ├─────────────┼────────────────────┼───────────────────┤
2024-11-22T20:33:04.8590211Z │ default     │                    │ Yes               │
2024-11-22T20:33:04.8590742Z └─────────────┴────────────────────┴───────────────────┘
2024-11-22T20:33:05.0083324Z Slack webhook URL provided. Sending Slack notification...
2024-11-22T20:33:05.0083887Z 
2024-11-22T20:33:05.0083959Z 
2024-11-22T20:33:05.0084775Z   GitHub Workflow Run Success: CI/CD Pipeline with Border0 GitHub Action (https://github.com/borderzero/experiment/actions/runs/11979685482)
2024-11-22T20:33:05.0085727Z 
2024-11-22T20:33:05.0086421Z Hey, th3wingman. Your github workflow is running Border0 Socket. You can click the link below to log in and troubleshoot:
2024-11-22T20:33:05.0088036Z https://client.border0.com/#/ssh/borderzero-experiment-11979685482-2-rnd.border0.io?org=rnd
2024-11-22T20:33:05.0088779Z 
2024-11-22T20:33:05.0089728Z Alternatively, use the following command to ssh into this GitHub VM:
2024-11-22T20:33:05.0090798Z $> border0 client ssh runner@borderzero-experiment-11979685482-2-rnd.border0.io
2024-11-22T20:33:05.0091828Z   
2024-11-22T20:33:05.0209548Z Waiting for 15 minute(s) before proceeding...
2024-11-22T20:33:05.1349928Z Successfully updated tags for socket borderzero-experiment-11979685482-2
2024-11-22T20:33:05.1722057Z Message sent to Slack successfully.
2024-11-22T20:41:25.4946739Z Process has exited early. Running cleanup...
2024-11-22T20:41:25.9384537Z Socket borderzero-experiment-11979685482-2 deleted
2024-11-22T20:41:25.9482032Z Cleaning up orphan processes